### PR TITLE
Fix for missing pop

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -362,6 +362,7 @@ local function parcelGUI()
             renderItems()
         end
 
+        ImGui.PopStyleColor()
         ImGui.End()
     end
 end


### PR DESCRIPTION
Was causing crashes when the window was opened with the new MQ/imGui update.

Further issues, if they exist, have not been examined, but I was able to successfully open the window and send a bunch of collectibles.